### PR TITLE
Added basic support for migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,26 @@ Import the `NgxIndexedDBModule` and initiate it:
 ```js
 import { NgxIndexedDBModule } from 'ngx-indexed-db';
 
-const dbConfig: DBConfig  = {name: 'MyDb', version: 1, objectStoresMeta: [
-  {
+const dbConfig: DBConfig  = {
+  name: 'MyDb',
+  version: 1,
+  objectStoresMeta: [{
     store: 'people',
     storeConfig: { keyPath: 'id', autoIncrement: true },
     storeSchema: [
       { name: 'name', keypath: 'name', options: { unique: false } },
       { name: 'email', keypath: 'email', options: { unique: false } }
     ]
+  }],
+  objectStoresMigration: {
+    2: (db, transaction) => {
+      // add a new indexed for version 2 of the store
+      const store = transaction.objectStore("people");
+      store.createIndex('phone', 'phone', { unique: false });
+      store.createIndex('age', 'age', { unique: false });
+    }
   }
-]};
+};
 
 @NgModule({
   ...

--- a/projects/ngx-indexed-db/src/lib/ngx-indexed-db.service.ts
+++ b/projects/ngx-indexed-db/src/lib/ngx-indexed-db.service.ts
@@ -17,7 +17,7 @@ export class NgxIndexedDBService {
 		if (!dbConfig.version) {
 			throw new Error('NgxIndexedDB: Please, provide the db version in the configuration');
 		}
-		CreateObjectStore(dbConfig.name, dbConfig.version, dbConfig.objectStoresMeta);
+		CreateObjectStore(dbConfig.name, dbConfig.version, dbConfig.objectStoresMeta, dbConfig.objectStoresMigration);
 	}
 
 	add<T>(value: T, key?: any) {

--- a/projects/ngx-indexed-db/src/lib/ngx-indexed-db.ts
+++ b/projects/ngx-indexed-db/src/lib/ngx-indexed-db.ts
@@ -46,15 +46,15 @@ export function openDatabase(dbName: string, version: number, upgradeCallback?: 
 }
 
 export function CreateObjectStore(
-  dbName: string,
-  version: number,
-  storeSchemas: ObjectStoreMeta[],
-  storeMigrations?: { [key: number]: (db: IDBDatabase, transaction: IDBTransaction) => void }
+	dbName: string,
+	version: number,
+	storeSchemas: ObjectStoreMeta[],
+	storeMigrations?: { [key: number]: (db: IDBDatabase, transaction: IDBTransaction) => void }
 ) {
 	const request: IDBOpenDBRequest = indexedDB.open(dbName, version);
 
 	request.onupgradeneeded = function(event: IDBVersionChangeEvent) {
-    const database: IDBDatabase = (event.target as any).result;
+		const database: IDBDatabase = (event.target as any).result;
 
 		storeSchemas.forEach((storeSchema: ObjectStoreMeta) => {
 			if (!database.objectStoreNames.contains(storeSchema.store)) {
@@ -63,20 +63,20 @@ export function CreateObjectStore(
 					objectStore.createIndex(schema.name, schema.keypath, schema.options);
 				});
 			}
-    });
+		});
 
-    if (storeMigrations) {
-      Object.keys(storeMigrations)
-        .map(k => parseInt(k, 10))
-        .filter(v => v > event.oldVersion)
-        .sort()
-        .forEach(v => {
-          storeMigrations[v](database, request.transaction);
-        });
-    }
+		if (storeMigrations) {
+			Object.keys(storeMigrations)
+				.map(k => parseInt(k, 10))
+				.filter(v => v > event.oldVersion)
+				.sort()
+				.forEach(v => {
+					storeMigrations[v](database, request.transaction);
+				});
+		}
 
-    database.close();
-  };
+		database.close();
+	};
 
 	request.onsuccess = function(e: any) {
 		e.target.result.close();

--- a/projects/ngx-indexed-db/src/lib/ngxindexeddb.module.ts
+++ b/projects/ngx-indexed-db/src/lib/ngxindexeddb.module.ts
@@ -7,6 +7,7 @@ export interface DBConfig {
 	name: string;
 	version: number;
 	objectStoresMeta: ObjectStoreMeta[];
+	objectStoresMigration?: { [key: number]: (db: IDBDatabase, transaction: IDBTransaction) => void };
 }
 
 export interface ObjectStoreMeta {


### PR DESCRIPTION
This allows you to pass in handlers for each db version. It will apply every version greater than the old version. 

The down side to this is that it bypasses the abstraction for the migration handlers. I debated if I wanted to attempt to abstract this in any way, but decided it was best to allow the underlying objects to be exposed for greater migration flexibility.

I am not sure if this is inline with what you had in mind, so feel free to reject this, but the latest version was unusable for me without the ability to apply migrations between versions. 
