### PR TITLE
fix(migrations): added support for aot

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,60 @@ const dbConfig: DBConfig  = {
       { name: 'name', keypath: 'name', options: { unique: false } },
       { name: 'email', keypath: 'email', options: { unique: false } }
     ]
-  }],
-  objectStoresMigration: {
-    2: (db, transaction) => {
-      // add a new indexed for version 2 of the store
+  }]
+};
+
+@NgModule({
+  ...
+  imports: [
+    ...
+    NgxIndexedDBModule.forRoot(dbConfig)
+  ],
+  ...
+})
+```
+
+### Migrations
+
+```
+import { NgxIndexedDBModule } from 'ngx-indexed-db';
+
+// Ahead of time compiles requires an exported function for factories
+export function migrationFactory() {
+  // The animal table was added but none of the existing
+  // tables or data needed to be modifies so a migrator is not included.
+  return {
+    1: (db, transaction) => {
       const store = transaction.objectStore("people");
-      store.createIndex('phone', 'phone', { unique: false });
+      store.createIndex('country', 'country', { unique: false });
+    },
+    3: (db, transaction) => {
+      const store = transaction.objectStore("people");
       store.createIndex('age', 'age', { unique: false });
     }
-  }
+  };
+}
+
+const dbConfig: DBConfig  = {
+  name: 'MyDb',
+  version: 3,
+  objectStoresMeta: [{
+    store: 'people',
+    storeConfig: { keyPath: 'id', autoIncrement: true },
+    storeSchema: [
+      { name: 'name', keypath: 'name', options: { unique: false } },
+      { name: 'email', keypath: 'email', options: { unique: false } }
+    ]
+  }, {
+    // animals added in version 2
+    store: 'animals',
+    storeConfig: { keyPath: 'id', autoIncrement: true },
+    storeSchema: [
+      { name: 'name', keypath: 'name', options: { unique: true } },
+    ]
+  }],
+  // provide the migration factory to the DBConfig
+  migrationFactory
 };
 
 @NgModule({

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ import { NgxIndexedDBModule } from 'ngx-indexed-db';
 
 // Ahead of time compiles requires an exported function for factories
 export function migrationFactory() {
-  // The animal table was added but none of the existing
-  // tables or data needed to be modifies so a migrator is not included.
+  // The animal table was added with version 2 but none of the existing tables or data needed
+  // to be modified so a migrator for that version is not included.
   return {
     1: (db, transaction) => {
       const store = transaction.objectStore("people");

--- a/projects/ngx-indexed-db/src/lib/ngx-indexed-db.service.ts
+++ b/projects/ngx-indexed-db/src/lib/ngx-indexed-db.service.ts
@@ -17,7 +17,7 @@ export class NgxIndexedDBService {
 		if (!dbConfig.version) {
 			throw new Error('NgxIndexedDB: Please, provide the db version in the configuration');
 		}
-		CreateObjectStore(dbConfig.name, dbConfig.version, dbConfig.objectStoresMeta, dbConfig.objectStoresMigration);
+		CreateObjectStore(dbConfig.name, dbConfig.version, dbConfig.objectStoresMeta, dbConfig.migrationFactory);
 	}
 
 	add<T>(value: T, key?: any) {

--- a/projects/ngx-indexed-db/src/lib/ngxindexeddb.module.ts
+++ b/projects/ngx-indexed-db/src/lib/ngxindexeddb.module.ts
@@ -7,7 +7,7 @@ export interface DBConfig {
 	name: string;
 	version: number;
 	objectStoresMeta: ObjectStoreMeta[];
-	objectStoresMigration?: { [key: number]: (db: IDBDatabase, transaction: IDBTransaction) => void };
+	migrationFactory?: () => { [key: number]: (db: IDBDatabase, transaction: IDBTransaction) => void };
 }
 
 export interface ObjectStoreMeta {


### PR DESCRIPTION
The initial version didn't support ahead of time compilation. This version uses a factory function, which seems to be the common practice for other libraries. 

I apologize again for not catching this the first time. 

