### PR TITLE
Fix wrong catch statement

### DIFF
--- a/projects/ngx-indexed-db/src/lib/ngx-indexed-db.service.ts
+++ b/projects/ngx-indexed-db/src/lib/ngx-indexed-db.service.ts
@@ -172,17 +172,18 @@ export class NgxIndexedDBService {
 
 	deleteDatabase() {
 		return new Promise(async (resolve, reject) => {
-			openDatabase(this.indexedDB, this.dbConfig.name, this.dbConfig.version)
-			.then(db => {
-				db.close();
+			try {
+				const db = await openDatabase(this.indexedDB, this.dbConfig.name, this.dbConfig.version);
+				await db.close();
 				const deleteDBRequest = this.indexedDB.deleteDatabase(this.dbConfig.name);
 				deleteDBRequest.onsuccess = resolve;
 				deleteDBRequest.onerror = reject;
 				deleteDBRequest.onblocked = () => {
 					throw new Error("Unable to delete database because it's blocked");
 				};
-			})
-			.catch(reason => reject(reason));
+			} catch (e) {
+				reject(e);
+			}
 		});
 	}
 

--- a/projects/ngx-indexed-db/src/lib/ngx-indexed-db.service.ts
+++ b/projects/ngx-indexed-db/src/lib/ngx-indexed-db.service.ts
@@ -172,14 +172,17 @@ export class NgxIndexedDBService {
 
 	deleteDatabase() {
 		return new Promise(async (resolve, reject) => {
-			const db = await openDatabase(this.indexedDB, this.dbConfig.name, this.dbConfig.version);
-			await db.close();
-			const deleteDBRequest = this.indexedDB.deleteDatabase(this.dbConfig.name).catch(reason => reject(reason));
-			deleteDBRequest.onsuccess = resolve;
-			deleteDBRequest.onerror = reject;
-			deleteDBRequest.onblocked = () => {
-				throw new Error("Unable to delete database because it's blocked");
-			};
+			openDatabase(this.indexedDB, this.dbConfig.name, this.dbConfig.version)
+			.then(db => {
+				db.close();
+				const deleteDBRequest = this.indexedDB.deleteDatabase(this.dbConfig.name);
+				deleteDBRequest.onsuccess = resolve;
+				deleteDBRequest.onerror = reject;
+				deleteDBRequest.onblocked = () => {
+					throw new Error("Unable to delete database because it's blocked");
+				};
+			})
+			.catch(reason => reject(reason));
 		});
 	}
 


### PR DESCRIPTION
In #193 I've added a catch statement at the wrong line (method `deleteDatabase`).
This fix introduces the correct use of `then/catch` for the mentioned method. 

Could you please double check?