### PR TITLE
Fix TSLint errors.

### DIFF
--- a/projects/ngx-indexed-db/src/lib/ngx-indexed-db.ts
+++ b/projects/ngx-indexed-db/src/lib/ngx-indexed-db.ts
@@ -22,7 +22,12 @@ export interface RequestEvent<T> extends Event {
   target: RequestEventTarget<T>;
 }
 
-export function openDatabase(indexedDB: IDBFactory, dbName: string, version: number, upgradeCallback?: Function) {
+export function openDatabase(
+  indexedDB: IDBFactory,
+  dbName: string,
+  version: number,
+  upgradeCallback?: (a: Event, b: IDBDatabase) => void
+): Promise<IDBDatabase> {
   return new Promise<IDBDatabase>((resolve, reject) => {
     if (!indexedDB) {
       reject('IndexedDB not available');
@@ -50,13 +55,13 @@ export function CreateObjectStore(
   version: number,
   storeSchemas: ObjectStoreMeta[],
   migrationFactory?: () => { [key: number]: (db: IDBDatabase, transaction: IDBTransaction) => void }
-) {
+): void {
   if (!indexedDB) {
     return;
   }
   const request: IDBOpenDBRequest = indexedDB.open(dbName, version);
 
-  request.onupgradeneeded = function(event: IDBVersionChangeEvent) {
+  request.onupgradeneeded = (event: IDBVersionChangeEvent) => {
     const database: IDBDatabase = (event.target as any).result;
 
     storeSchemas.forEach((storeSchema: ObjectStoreMeta) => {
@@ -82,7 +87,7 @@ export function CreateObjectStore(
     database.close();
   };
 
-  request.onsuccess = function(e: any) {
+  request.onsuccess = (e: any) => {
     e.target.result.close();
   };
 }

--- a/projects/ngx-indexed-db/src/utils/index.ts
+++ b/projects/ngx-indexed-db/src/utils/index.ts
@@ -6,11 +6,11 @@ export interface Options {
   abort?: any;
 }
 
-export function validateStoreName(db: IDBDatabase, storeName: string) {
+export function validateStoreName(db: IDBDatabase, storeName: string): boolean {
   return db.objectStoreNames.contains(storeName);
 }
 
-export function validateBeforeTransaction(db: IDBDatabase, storeName: string, reject: Function) {
+export function validateBeforeTransaction(db: IDBDatabase, storeName: string, reject: (message: string) => void): void {
   if (!db) {
     reject('You need to use the openDatabase function to create a database before you query it!');
   }
@@ -20,16 +20,16 @@ export function validateBeforeTransaction(db: IDBDatabase, storeName: string, re
 }
 
 export function createTransaction(db: IDBDatabase, options: Options): IDBTransaction {
-  let trans: IDBTransaction = db.transaction(options.storeName, options.dbMode);
+  const trans: IDBTransaction = db.transaction(options.storeName, options.dbMode);
   trans.onerror = options.error;
   trans.oncomplete = options.complete;
   trans.onabort = options.abort;
   return trans;
 }
 
-export function optionsGenerator(type: any, storeName: any, reject: Function, resolve: Function): Options {
+export function optionsGenerator(type: any, storeName: any, reject: (reason?: any) => void, resolve: () => void): Options {
   return {
-    storeName: storeName,
+    storeName,
     dbMode: type,
     error: (e: Event) => {
       reject(e);


### PR DESCRIPTION
This PR resolve #201 .

I fixed the following issues.
```
projects/ngx-indexed-db/src/lib/ngx-indexed-db.ts:25:17
ERROR: 25:17   typedef                   expected call-signature: 'openDatabase' to have a typedef
ERROR: 25:104  ban-types                 Don't use 'Function' as a type. Avoid using the `Function` type. Prefer a specific function type, like `() => void`.
ERROR: 47:17   typedef                   expected call-signature: 'CreateObjectStore' to have a typedef
ERROR: 59:29   only-arrow-functions      non-arrow functions are forbidden
ERROR: 59:37   typedef                   expected call-signature to have a typedef
ERROR: 85:23   only-arrow-functions      non-arrow functions are forbidden
ERROR: 85:31   typedef                   expected call-signature to have a typedef

projects/ngx-indexed-db/src/utils/index.ts:9:17
ERROR: 9:17    typedef                   expected call-signature: 'validateStoreName' to have a typedef
ERROR: 13:17   typedef                   expected call-signature: 'validateBeforeTransaction' to have a typedef
ERROR: 13:87   ban-types                 Don't use 'Function' as a type. Avoid using the `Function` type. Prefer a specific function type, like `() => void`.
ERROR: 23:7    prefer-const              Identifier 'trans' is never reassigned; use 'const' instead of 'let'.
ERROR: 30:69   ban-types                 Don't use 'Function' as a type. Avoid using the `Function` type. Prefer a specific function type, like `() => void`.
ERROR: 30:88   ban-types                 Don't use 'Function' as a type. Avoid using the `Function` type. Prefer a specific function type, like `() => void`.
ERROR: 32:5    object-literal-shorthand  Expected property shorthand in object literal ('{storeName}').
```