### PR TITLE
Added getAllKeysByIndex method to service

### DIFF
--- a/projects/ngx-indexed-db/src/lib/ngx-indexed-db.service.ts
+++ b/projects/ngx-indexed-db/src/lib/ngx-indexed-db.service.ts
@@ -387,7 +387,7 @@ export class NgxIndexedDBService {
             request.onsuccess = (event) => {
               const cursor: IDBCursor = (event.target as IDBRequest<IDBCursor>).result;
               if (cursor) {
-                data.push({primaryKey: cursor.primaryKey, key: cursor.key})
+                data.push({primaryKey: cursor.primaryKey, key: cursor.key});
                 cursor.continue();
               } else {
                 resolve(data);


### PR DESCRIPTION
Fixes: #225

Currently there wasn't a clear way to query the database for multiple records without pulling in all the data for those records into memory (see #225 )

Therefore, have added a new variant of `getAllByIndex` named `getAllKeysByIndex` which uses `openKeyCursor` to return the primary keys of a query rather than `openCursor` which returns the full content.

This provides a quick way to return query results in a lightweight way, and may be more generally useful to others so issuing a PR.