### PR TITLE
fix: use npm instead yarn

### DIFF
--- a/.github/workflows/buid.yml
+++ b/.github/workflows/buid.yml
@@ -29,6 +29,5 @@ jobs:
 
       - name: npm ci and npm run build
         run: |
-          npm i -g yarn
-          yarn install --immutable --immutable-cache --check-cache
-          yarn run build:lib
+          npm install --immutable --immutable-cache --check-cache
+          npm run build:lib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,5 @@ jobs:
 
       - name: npm ci and npm run build
         run: |
-          npm i -g yarn
-          yarn install --immutable --immutable-cache --check-cache
-          yarn run build:lib
+          npm install --immutable --immutable-cache --check-cache
+          npm run build:lib

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -14,10 +14,9 @@ jobs:
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/
-      - run: npm install -g yarn
-      - run: yarn install
-      - run: yarn pack
-      - run: yarn run build:lib
+      - run: npm install
+      - run: npm pack
+      - run: npm run build:lib
       - name: Publish
         working-directory: ./dist/ngx-indexed-db
         run: npm publish --access public


### PR DESCRIPTION
This pull request includes changes to the GitHub workflows to standardize the usage of npm instead of yarn for package management and building the project. The most important changes are as follows:

Standardization of package management:

* [`.github/workflows/buid.yml`](diffhunk://#diff-83b17fd7c11065e116dca1aba51ebc35e5e70de83c909d42b681d1576e36877dL32-R33): Replaced yarn commands with npm commands for installing dependencies and building the library.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL32-R33): Replaced yarn commands with npm commands for installing dependencies and building the library.
* [`.github/workflows/release-package.yml`](diffhunk://#diff-3099c6260c6951cb01f86e1ae6d3445e822dfd243571b51a1737ec2cee3a7e56L17-R19): Replaced yarn commands with npm commands for installing dependencies, packing, and building the library.