### PR TITLE
The reject function is being used to propagate an error

### DIFF
--- a/projects/ngx-indexed-db/src/utils/index.ts
+++ b/projects/ngx-indexed-db/src/utils/index.ts
@@ -13,6 +13,7 @@ export function validateStoreName(db: IDBDatabase, storeName: string): boolean {
 export function validateBeforeTransaction(db: IDBDatabase, storeName: string, reject: (message: string) => void): void {
   if (!db) {
     reject('You need to use the openDatabase function to create a database before you query it!');
+    return; // Stop further execution
   }
   if (!validateStoreName(db, storeName)) {
     reject(`objectStore does not exists: ${storeName}`);


### PR DESCRIPTION
The reject function is being used to propagate an error, but this could lead to issues if the reject function is called multiple times. 