### PR TITLE
feat: apply no-unused-vars rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -36,7 +36,6 @@ module.exports = tseslint.config(
       "@typescript-eslint/consistent-indexed-object-style": "off",
       "@typescript-eslint/consistent-type-definitions": "off",
       "@typescript-eslint/no-explicit-any" : "off",
-      "@typescript-eslint/no-unused-vars": "off"
     },
   },
   {

--- a/projects/ngx-indexed-db/src/lib/ngx-indexed-db.service.ts
+++ b/projects/ngx-indexed-db/src/lib/ngx-indexed-db.service.ts
@@ -179,7 +179,7 @@ export class NgxIndexedDBService {
           const objectStore = transaction.objectStore(storeName);
 
           const results = values.map((value) => {
-            return new Promise<number>((resolve1, reject1) => {
+            return new Promise<number>((resolve1) => {
               const key = value.key;
               delete value.key;
 

--- a/projects/ngx-indexed-db/src/lib/ngx-indexed-db.ts
+++ b/projects/ngx-indexed-db/src/lib/ngx-indexed-db.ts
@@ -15,12 +15,12 @@ export function openDatabase(
     }
     const request = indexedDB.open(dbName, version);
     let db: IDBDatabase;
-    request.onsuccess = (event: Event) => {
+    request.onsuccess = () => {
       db = request.result;
       openedDatabases.push(db);
       resolve(db);
     };
-    request.onerror = (event: Event) => {
+    request.onerror = () => {
       reject(`IndexedDB error: ${request.error}`);
     };
     if (typeof upgradeCallback === 'function') {

--- a/projects/ngx-indexed-db/src/lib/ngxindexeddb.module.ts
+++ b/projects/ngx-indexed-db/src/lib/ngxindexeddb.module.ts
@@ -1,4 +1,4 @@
-import { NgModule, ModuleWithProviders, InjectionToken } from '@angular/core';
+import { NgModule, ModuleWithProviders } from '@angular/core';
 import { DBConfig } from './ngx-indexed-db.meta';
 import { _provideIndexedDb } from './provide-indexed-db';
 

--- a/projects/ngx-indexed-db/src/lib/provide-indexed-db.ts
+++ b/projects/ngx-indexed-db/src/lib/provide-indexed-db.ts
@@ -1,5 +1,5 @@
 import { makeEnvironmentProviders, Provider } from '@angular/core';
-import { DBConfig, CONFIG_TOKEN, INDEXED_DB, SERVER_INDEXED_DB } from './ngx-indexed-db.meta';
+import { DBConfig, CONFIG_TOKEN, INDEXED_DB } from './ngx-indexed-db.meta';
 import { NgxIndexedDBService } from './ngx-indexed-db.service';
 import { indexedDbFactory } from '../ssr';
 

--- a/projects/ngx-indexed-db/src/utils/index.ts
+++ b/projects/ngx-indexed-db/src/utils/index.ts
@@ -31,6 +31,7 @@ export function optionsGenerator(
   type: any,
   storeName: any,
   reject: (reason?: any) => void,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   resolve?: (e: any) => void
 ): Options {
   return {

--- a/projects/ssr-playground/src/app/app.config.ts
+++ b/projects/ssr-playground/src/app/app.config.ts
@@ -3,7 +3,7 @@ import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
 import { provideClientHydration } from '@angular/platform-browser';
-import { provideIndexedDb, DBConfig, SERVER_INDEXED_DB } from 'ngx-indexed-db';
+import { provideIndexedDb, DBConfig } from 'ngx-indexed-db';
 
 const dbConfig: DBConfig = {
   name: 'MyDb',


### PR DESCRIPTION
I used // eslint-disable-next-line @typescript-eslint/no-unused-vars to keep the same method definition and prevent a small refactoring in this PR.